### PR TITLE
chore(package.json): fix gulp-sourcemaps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "duplexify": "^3.4.3",
     "glob-stream": "^5.3.2",
     "graceful-fs": "^4.1.3",
-    "gulp-sourcemaps": "^2.0.0-alpha",
+    "gulp-sourcemaps": "^1.7.1",
     "is-valid-glob": "^0.3.0",
     "merge-stream": "^1.0.0",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
gulp-sourcemaps v2 is published and does not support node v0.10/0.12.
We want to support node v0.10/0.12 for now, so it's better to keep ^1.7.1.

ref. https://github.com/kt3k/vinyl-bundle/pull/8
